### PR TITLE
adding new endpoint /api/dropdowns?<params>. 

### DIFF
--- a/retina-api/retina-api/Controllers/DropdownsController.cs
+++ b/retina-api/retina-api/Controllers/DropdownsController.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json.Linq;
+using retina_api.Models;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace retina_api.Controllers
+{
+    public class DropdownsController : ApiController
+    {
+        [HttpGet]
+        public IHttpActionResult getDropdowns(int? currentUser, bool? user, bool? brand, bool? provider, bool? status, bool? type, bool? restricteduser)
+        {
+
+            try
+            {
+                Dropdown d = new Dropdown();
+
+                if (brand == true)
+                {
+                    d.attributes.brand = new UniqueNames("select_brand").getUniqueStrings("Brand");
+                }
+             
+                if (provider == true)
+                {
+                    d.attributes.provider = new UniqueNames("select_purchased_from").getUniqueStrings("PurchasedFrom");
+                }
+
+                if (status == true)
+                {
+                    d.attributes.status = new UniqueNames("select_status").getUniqueStrings("Status");
+                }
+
+                if (type == true)
+                {
+                    d.attributes.type = new UniqueNames("select_type").getUniqueStrings("Type");
+                }
+             
+                if (user == true)
+                {
+                    d.attributes.user = new UniqueNames("select_user").getUniqueDynamics();
+                }
+
+                if (currentUser != null && restricteduser == true)
+                {
+                    UniqueNames limitedUnique = new UniqueNames("select_limited_user");
+                    limitedUnique.cmd.Parameters.AddWithValue("@CurrentUser", currentUser);
+                    d.attributes.restricteduser = limitedUnique.getUniqueDynamics();
+                }
+
+                return Ok(new { data = d });
+            }
+            catch (Exception e)
+            {
+                return Ok(e);
+            }
+        }
+    }
+}

--- a/retina-api/retina-api/Controllers/ToolsController.cs
+++ b/retina-api/retina-api/Controllers/ToolsController.cs
@@ -35,7 +35,7 @@ namespace retina_api.Controllers
 
                 myConnector.closeConnection();
 
-                return (new { data = tool });
+                return Ok(new { data = tool });
 
             }
             catch (Exception e)

--- a/retina-api/retina-api/Controllers/UsersController.cs
+++ b/retina-api/retina-api/Controllers/UsersController.cs
@@ -20,7 +20,7 @@ namespace retina_api.Controllers
                 List<dynamic> uniqueDynamics = new UniqueNames("select_user").getUniqueDynamics();
                 return Ok(new { users = uniqueDynamics });
 
-            }catch (Exception e)
+            } catch (Exception e)
             {
                 return Ok(e);
             }

--- a/retina-api/retina-api/Models/Dropdown.cs
+++ b/retina-api/retina-api/Models/Dropdown.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace retina_api.Models
+{
+    public class Dropdown
+    {
+
+        public string type { get; }
+        public int id { get; }
+        public attributes attributes { get; set; }
+
+        public Dropdown()
+        {
+
+            type = "dropdown";
+            id = 1;
+            attributes = new attributes();
+        }
+    }
+}

--- a/retina-api/retina-api/Models/attributes.cs
+++ b/retina-api/retina-api/Models/attributes.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace retina_api.Models
+{
+    public class attributes
+    {
+
+        public List<dynamic> user { get; set; }
+        public List<dynamic> restricteduser { get; set; }
+        public List<string> brand { get; set; }
+        public List<string> type { get; set; }
+        public List<string> status { get; set; }
+        public List<string> provider { get; set; }
+
+        public attributes()
+        {
+
+        }
+    }
+}

--- a/retina-api/retina-api/retina-api.csproj
+++ b/retina-api/retina-api/retina-api.csproj
@@ -108,12 +108,14 @@
   <ItemGroup>
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\BrandsController.cs" />
+    <Compile Include="Controllers\DropdownsController.cs" />
     <Compile Include="Controllers\UsersController.cs" />
     <Compile Include="Controllers\StatusController.cs" />
     <Compile Include="Controllers\ProvidersController.cs" />
     <Compile Include="Controllers\TokenController.cs" />
     <Compile Include="Controllers\TransferController.cs" />
     <Compile Include="Controllers\TypesController.cs" />
+    <Compile Include="Models\attributes.cs" />
     <Compile Include="Models\Tool.cs" />
     <Compile Include="Models\DBConnector.cs" />
     <Compile Include="Controllers\SearchController.cs" />
@@ -122,6 +124,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Models\UniqueNames.cs" />
+    <Compile Include="Models\Dropdown.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
NOTE: this pr does not remove any old functionality. Only adds a new endpoint that we can use and test. If we like it then we can remove the endpoints this new endpoint was designed to replace

Would replace the individual requests that must be made for each dropdown. This will reduce the requests down significantly and hopefully improve performance.

request accepts boolean params for each dropdown.

brand
provider
status
type
users
restrictedUser